### PR TITLE
Removed bs4 requirement for login_info

### DIFF
--- a/pyalarmdotcomajax/__init__.py
+++ b/pyalarmdotcomajax/__init__.py
@@ -1,3 +1,3 @@
 """pyalarmdotcomajax module."""
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 from .pyalarmdotcomajax import Alarmdotcom

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 # Dev/Deployment
-bs4
 aiohttp


### PR DESCRIPTION
Replaced bs4 tree select for finding login info with re and a function to parse returned data from response text. Not sure if this will allow for Alarm.com to be integrated back into HA or if this still would be flagged as 'web scraping'. I have tested on my HA install and believe everything to be in working order.