### PR TITLE
Add "armed night" to the alarm state map

### DIFF
--- a/pyalarmdotcomajax/pyalarmdotcomajax.py
+++ b/pyalarmdotcomajax/pyalarmdotcomajax.py
@@ -39,6 +39,7 @@ class Alarmdotcom:
         "disarmed",
         "armed stay",
         "armed away",
+        "armed night",
     )  # index is ADC's json status, value is integration's status
     GARAGE_DOOR_STATEMAP = (
         "Transitioning",  # 0


### PR DESCRIPTION
My alarm panel offers a Armed Night mode, and this adds the index for this mode to the parsing code.