### PR TITLE
Add `main` function to `pyalarmdotcomajax`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python: Current File",
+      "type": "python",
+      "request": "launch",
+      "program": "${file}",
+      "console": "integratedTerminal",
+    }
+  ]
+}

--- a/pyalarmdotcomajax/pyalarmdotcomajax.py
+++ b/pyalarmdotcomajax/pyalarmdotcomajax.py
@@ -618,3 +618,49 @@ class AlarmdotcomProtection1(AlarmdotcomADT):
             except (KeyError, IndexError):
                 _LOGGER.error("Unable to log in")
                 return False
+
+# Main function used for command-line develpment and testing. Not used in normal library operation.
+async def main():
+    import os
+
+    username = os.getenv("ALARM_DOT_COM_USERNAME")
+    password = os.getenv("ALARM_DOT_COM_PASSWORD")
+    if username is None or password is None:
+        print("Set env ALARM_DOT_COM_USERNAME and ALARM_DOT_COM_PASSWORD for this to work")
+
+    twoFactorCookie = os.getenv("ALARM_DOT_COM_2FA_COOKIE")
+
+    print("Logging in with user: " + username + ", password: " + password)
+    if twoFactorCookie is not None:
+        print("Using 2FA cookie: " + twoFactorCookie)
+
+    print()
+    async with aiohttp.ClientSession() as session:
+        alarmCom = Alarmdotcom(
+            username,
+            password,
+            session,
+            False, # ForceBypass
+            False, # NoEntryDelay
+            False, # SilentArming
+            twoFactorCookie)
+
+        await alarmCom.async_login()
+        print("Logged in")
+        await alarmCom.async_update()
+        await alarmCom.async_update("lock")
+        print("Update success")
+        print()
+        print("State is:")
+        print(alarmCom.state)
+        print()
+
+        print("Detailed status is:")
+        print(alarmCom.sensor_status_detailed)
+        print()
+
+        print("Sensor status is:")
+        print(alarmCom.sensor_status)
+
+if __name__=="__main__":
+    asyncio.run(main())


### PR DESCRIPTION
This is extremely useful to me to debug/test using the command line without having to deploy Home Assistant.
    
Figured I'd see if anyone else would find this useful, assuming this pattern doesn't break anything for consumers... in my testing with HASS it did not.