### PR TITLE
Fix crashes on unavailable entity types

### DIFF
--- a/pyalarmdotcomajax/const.py
+++ b/pyalarmdotcomajax/const.py
@@ -103,3 +103,28 @@ class ADCGarageDoorCommand(Enum):
 
     OPEN = "open"
     CLOSE = "close"
+
+
+# class DeviceTypeFetchErrors(TypedDict, total=False):
+#     """Store all errors encountered when fetching devices."""
+
+#     systems: DeviceTypeFetchError | None
+#     partitions: DeviceTypeFetchError | None
+#     locks: DeviceTypeFetchError | None
+#     sensors: DeviceTypeFetchError | None
+#     garageDoors: DeviceTypeFetchError | None
+
+
+# class DeviceTypeFetchError(TypedDict):
+#     """Store errors encountered when fetching a particular device type."""
+
+#     device_type: ADCDeviceType
+#     errors: list[ADCError]
+
+
+# class ADCError(TypedDict):
+#     """Alarm.com response error format."""
+
+#     status: str
+#     detail: str
+#     code: str

--- a/pyalarmdotcomajax/entities.py
+++ b/pyalarmdotcomajax/entities.py
@@ -253,7 +253,7 @@ class ADCPartition(DesiredStateMixin, ADCBaseElement):
 
 
 class ADCLock(DesiredStateMixin, ADCBaseElement):
-    """Represent Alarm.com partition element."""
+    """Represent Alarm.com sensor element."""
 
     class DeviceState(Enum):
         """Enum of lock states."""
@@ -303,7 +303,7 @@ class ADCSensor(ADCBaseElement):
 
 
 class ADCGarageDoor(DesiredStateMixin, ADCBaseElement):
-    """Represent Alarm.com system element."""
+    """Represent Alarm.com garage door element."""
 
     class DeviceState(Enum):
         """Enum of garage door states."""

--- a/pyalarmdotcomajax/errors.py
+++ b/pyalarmdotcomajax/errors.py
@@ -16,3 +16,11 @@ class DataFetchFailed(Exception):
 
 class UnexpectedDataStructure(Exception):
     """Successfully received JSON object, but format is not as expected."""
+
+
+class BadAccount(Exception):
+    """Account can't lock in or major permissions issue."""
+
+
+class DeviceTypeNotAuthorized(Exception):
+    """Account does not have access to a specific device type."""


### PR DESCRIPTION
Fixes crashes on plans/accounts without garage doors and locks. ADC _sometimes_ returns error 423 when pulling data for these entities. This is either because the user has not subscribed to a plan that supports these devices, because the provider does not support these devices, or because the devices are just not present on an account.