### PR TITLE
Set correct values for DeviceState in ADCLock

### DIFF
--- a/pyalarmdotcomajax/entities.py
+++ b/pyalarmdotcomajax/entities.py
@@ -243,9 +243,9 @@ class ADCLock(DesiredStateMixin, ADCBaseElement):
     class DeviceState(Enum):
         """Enum of lock states."""
 
-        FAILED = "Failed"
-        LOCKED = "Locked"
-        UNLOCKED = "Open"
+        FAILED = 0
+        LOCKED = 1
+        UNLOCKED = 2
 
     async def async_lock(self) -> None:
         """Send lock command."""


### PR DESCRIPTION
This fixes the issue with lock malfunctioning (i.e. failing to get the state).